### PR TITLE
squid:S2039 - Member variable visibility should be specified

### DIFF
--- a/opencdk/src/main/java/com/opencdk/view/viewpager/ViewPagerCompat.java
+++ b/opencdk/src/main/java/com/opencdk/view/viewpager/ViewPagerCompat.java
@@ -122,11 +122,11 @@ public class ViewPagerCompat extends ViewGroup {
     private int mExpectedAdapterCount;
 
     static class ItemInfo {
-        Object object;
-        int position;
-        boolean scrolling;
-        float widthFactor;
-        float offset;
+        private Object object;
+        private int position;
+        private boolean scrolling;
+        private float widthFactor;
+        private float offset;
     }
 
     private static final Comparator<ItemInfo> COMPARATOR = new Comparator<ItemInfo>(){
@@ -1228,9 +1228,9 @@ public class ViewPagerCompat extends ViewGroup {
      * contains that state.
      */
     public static class SavedState extends BaseSavedState {
-        int position;
-        Parcelable adapterState;
-        ClassLoader loader;
+        private int position;
+        private Parcelable adapterState;
+        private ClassLoader loader;
 
         public SavedState(Parcelable superState) {
             super(superState);
@@ -2871,23 +2871,23 @@ public class ViewPagerCompat extends ViewGroup {
         /**
          * Width as a 0-1 multiplier of the measured pager width
          */
-        float widthFactor = 0.f;
+        private float widthFactor = 0.f;
 
         /**
          * true if this view was added during layout and needs to be measured
          * before being positioned.
          */
-        boolean needsMeasure;
+        private boolean needsMeasure;
 
         /**
          * Adapter position this view is for if !isDecor
          */
-        int position;
+        private int position;
 
         /**
          * Current child index within the ViewPager that this view occupies
          */
-        int childIndex;
+        private int childIndex;
 
         public LayoutParams() {
             super(FILL_PARENT, FILL_PARENT);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2039 - Member variable visibility should be specified

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S2039

Please let me know if you have any questions.

M-Ezzat
